### PR TITLE
Fix a flaky test

### DIFF
--- a/src/test/java/com/github/ferstl/depgraph/GraphIntegrationTest.java
+++ b/src/test/java/com/github/ferstl/depgraph/GraphIntegrationTest.java
@@ -17,6 +17,8 @@ package com.github.ferstl.depgraph;
 
 import java.io.File;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,6 +29,8 @@ import io.takari.maven.testing.executor.MavenRuntime;
 import io.takari.maven.testing.executor.MavenRuntime.MavenRuntimeBuilder;
 import io.takari.maven.testing.executor.MavenVersions;
 import io.takari.maven.testing.executor.junit.MavenJUnitTestRunner;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import static com.github.ferstl.depgraph.MavenVersion.MAX_VERSION;
 import static com.github.ferstl.depgraph.MavenVersion.MIN_VERSION;
 import static io.takari.maven.testing.TestResources.assertFileContents;
@@ -46,6 +50,18 @@ public class GraphIntegrationTest {
     this.mavenRuntime = builder
         .withCliOptions("-B")
         .build();
+  }
+
+  public void assertJsonFileContents(File basedir, String expFile, String srcFile) throws Exception {
+    Path basePath = basedir.toPath();
+    Path expFilePath = basePath.resolve(expFile);
+    Path srcFilePath = basePath.resolve(srcFile);
+
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode treeExp = mapper.readTree(expFilePath.toFile());
+    JsonNode treeSrc = mapper.readTree(srcFilePath.toFile());
+
+    Assert.assertEquals(treeExp, treeSrc);
   }
 
   @Before
@@ -284,11 +300,11 @@ public class GraphIntegrationTest {
         "target/dependency-graph.json",
         "sub-parent/target/dependency-graph.json");
 
-    assertFileContents(basedir, "expectations/graph_parent.json", "target/dependency-graph.json");
-    assertFileContents(basedir, "expectations/graph_module-1.json", "module-1/target/dependency-graph.json");
-    assertFileContents(basedir, "expectations/graph_module-2.json", "module-2/target/dependency-graph.json");
-    assertFileContents(basedir, "expectations/graph_sub-parent.json", "sub-parent/target/dependency-graph.json");
-    assertFileContents(basedir, "expectations/graph_module-3.json", "sub-parent/module-3/target/dependency-graph.json");
+    assertJsonFileContents(basedir, "expectations/graph_parent.json", "target/dependency-graph.json");
+    assertJsonFileContents(basedir, "expectations/graph_module-1.json", "module-1/target/dependency-graph.json");
+    assertJsonFileContents(basedir, "expectations/graph_module-2.json", "module-2/target/dependency-graph.json");
+    assertJsonFileContents(basedir, "expectations/graph_sub-parent.json", "sub-parent/target/dependency-graph.json");
+    assertJsonFileContents(basedir, "expectations/graph_module-3.json", "sub-parent/module-3/target/dependency-graph.json");
   }
 
   @Test


### PR DESCRIPTION
### Description

Fixed a flaky test in `com.github.ferstl.depgraph.GraphIntegrationTest.graphInJson`.

 - To identify the flaky test, execute the following [nondex](https://github.com/TestingResearchIllinois/NonDex) command after compiling the module:
 ```shell
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=com.github.ferstl.depgraph.GraphIntegrationTest#graphInJson
```

 - The test instability arises from an incorrect assumption about the sequential arrangement of keys in JSON files. Two JSON files may be equivalent even if their text formats differ because the key order in JSON can vary without affecting the data structure.
 - The original test function `graphInJson` inaccurately compared the source JSON to the expected JSON by matching the text directly and asserting file content equivalence. This approach is overly stringent for JSON files, where key order can be non-deterministic.
 - To address this issue, a JSON comparison function has been implemented using the `Jackson` library, which properly compares JSON objects based on their content and structure, disregarding the order of keys.

<hr>


This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests
